### PR TITLE
Fix #125: Исправил баг с маркерами на CSS рендере

### DIFF
--- a/src/css/layout.styl
+++ b/src/css/layout.styl
@@ -7,4 +7,7 @@ body
     font $font-size 'HelveticaNeue', 'Helvetica Neue', Helvetica, Arial, sans-serif
 
 #renderer
+    position absolute
+    top 0
+    left 0
     user-select none

--- a/src/js/Tour/Marker.js
+++ b/src/js/Tour/Marker.js
@@ -26,8 +26,8 @@ Tour.Marker.prototype.draw = function() {
     var pos = (new THREE.Vector3(this.vector.x , this.vector.y , this.vector.z)).project(Tour.camera);
 
     if (pos.z < 1) {
-        var width = Tour.renderer.domElement.width / 2;
-        var height = Tour.renderer.domElement.height / 2;
+        var width = Tour.renderer.domElement.clientWidth / 2;
+        var height = Tour.renderer.domElement.clientHeight / 2;
 
         this.setPosition(
             (pos.x  * width  + width)  / window.devicePixelRatio,


### PR DESCRIPTION
Проблема была не в верстке. На Css рендере не работает `Tour.renderer.domElement.width` только `clientWidth`. Заодно поправил позиционирование `#renderer` т.к. из за `#background-image` он смещается.